### PR TITLE
[#5]FEAT: Add setting view and controller functions

### DIFF
--- a/app/home-page.jsx
+++ b/app/home-page.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import Header from '@/components/header';
 
 import CompanyList from '@/components/company_list';
+import Settings from '@/components/settings';
 
 export default function HomePage() {
   return (
@@ -13,8 +14,11 @@ export default function HomePage() {
       <Header />
       <Body>
         <Row1>
-          <div style={{ width: '25%' }}>
+          <div style={{ width: '30%' }}>
             <CompanyList />
+          </div>
+          <div style={{ width: '30%' }}>
+            <Settings />
           </div>
         </Row1>
       </Body>
@@ -29,7 +33,6 @@ const Body = styled.div`
 
 const Row1 = styled.div`
   width: 100%;
-  max-height: 90vh;
   display: flex;
   flex-direction: row;
   justify-content: space-around;

--- a/app/log/page.jsx
+++ b/app/log/page.jsx
@@ -26,7 +26,6 @@ const Body = styled.div`
 
 const Row1 = styled.div`
   width: 100%;
-  max-height: 90vh;
   display: flex;
   flex-direction: row;
   justify-content: space-around;

--- a/components/company_list.jsx
+++ b/components/company_list.jsx
@@ -32,10 +32,10 @@ export default function CompanyList() {
               <td>{company[1]}</td>
               <td>
                 {company[2] === '1' && (
-                  <input type="checkbox" id="scales" checked readOnly />
+                  <input name={company[0]} type="checkbox" checked readOnly />
                 )}
                 {company[2] === '0' && (
-                  <input type="checkbox" id="scales" readOnly />
+                  <input name={company[0]} type="checkbox" readOnly />
                 )}
               </td>
             </tr>
@@ -56,6 +56,7 @@ export default function CompanyList() {
 
   return (
     <Wrapper>
+      <h2>Company List</h2>
       <List>
         <table>
           <thead>
@@ -107,11 +108,25 @@ export default function CompanyList() {
 
 const Wrapper = styled.div`
   width: 100%;
-  height: 100%;
+  height: 90vh;
   display: flex;
   flex-direction: column;
-  justify-content: space-around;
+  justify-content: start;
   align-items: center;
+  overflow-y: visible;
+`;
+
+const List = styled.div`
+  width: 100%;
+  height: 60vh;
+  padding: 5%;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  border: 1px solid #333;
+  overflow-y: scroll;
 
   table {
     width: 100%;
@@ -129,22 +144,9 @@ const Wrapper = styled.div`
   }
 `;
 
-const List = styled.div`
-  width: 100%;
-  height: 50vh;
-  padding: 5%;
-
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-
-  border: 1px solid #333;
-  overflow-y: scroll;
-`;
-
 const Download = styled.div`
   width: 100%;
-  height: 100%;
+
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/components/logs.jsx
+++ b/components/logs.jsx
@@ -74,7 +74,7 @@ export default function Logs() {
           <SelectDates setStartDate={setStartDate} setEndDate={setEndDate} />
         </div>
       </LogHead>
-      <LogTable>{make_log_table(logs, sort_logs)}</LogTable>
+      {make_log_table(logs, sort_logs)}
     </Wrapper>
   );
 }
@@ -86,19 +86,11 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-`;
 
-const LogHead = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-`;
-
-const LogTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
 
   tr,
   th,
@@ -110,10 +102,24 @@ const LogTable = styled.table`
 
   th.keys_for_sort {
     cursor: pointer;
-    background-color: #ccc;
+    color: orange;
 
     :hover {
-      color: white;
+      color: coral;
+      scale: 1.05;
     }
   }
+
+  thead {
+    background-color: #333;
+    color: #fff;
+  }
+`;
+
+const LogHead = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 `;

--- a/components/micro_components/inputbox_message.jsx
+++ b/components/micro_components/inputbox_message.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+export default function InputboxMessage({
+  name,
+  defaultValue,
+  type,
+  range,
+  value,
+  setSettingValues,
+  setCheckChange,
+}) {
+  const [correct, setCorrect] = useState(true);
+
+  useEffect(() => {
+    if (range) {
+      if (value === '') {
+        setCorrect(true);
+      } else if (
+        (type === 'int' ? Number.isInteger(Number(value)) : true) &&
+        (range.hasOwnProperty('min') ? Number(value) >= range.min : true) &&
+        (range.hasOwnProperty('max') ? Number(value) <= range.max : true)
+      ) {
+        setCorrect(true);
+      } else {
+        setCorrect(false);
+      }
+    }
+  }, [value]);
+
+  useEffect(() => {
+    if (value === '' || !correct || Number(value) === defaultValue) {
+      setCheckChange(curr => {
+        const newValue = { ...curr };
+        newValue[name] = false;
+        return newValue;
+      });
+    } else {
+      setCheckChange(curr => {
+        const newValue = { ...curr };
+        newValue[name] = true;
+        return newValue;
+      });
+    }
+  }, [value, defaultValue, correct]);
+
+  return (
+    <Wrapper>
+      <input
+        name={name}
+        placeholder={defaultValue}
+        value={value}
+        onChange={e =>
+          setSettingValues(curr => {
+            const newValue = { ...curr };
+            newValue[name] = e.target.value;
+            return newValue;
+          })
+        }
+        style={{ textAlign: 'center' }}
+      />
+      <Mention correct={correct}>
+        {`Type: ${type}, `}
+        {range.hasOwnProperty('min') && `Min: ${range.min}`}
+        {range.hasOwnProperty('min') && range.hasOwnProperty('max') && ' '}
+        {range.hasOwnProperty('max') && `Max: ${range.max}`}
+      </Mention>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Mention = styled.p`
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 0.8em;
+  color: ${props => (props.correct ? 'green' : 'red')};
+`;

--- a/components/settings.jsx
+++ b/components/settings.jsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react';
+import Select from 'react-select';
+import styled from 'styled-components';
+
+import { get_default_settings, get_settings } from '@/services/settingapi';
+import { make_settings_table } from '@/utils/setting_handling';
+import { getCompanyList } from '@/services/backendapi';
+import { apply_new_setting } from '@/utils/setting_handling';
+
+export default function Settings() {
+  const [settingValues, setSettingValues] = useState({});
+  const [settingInfos, setSettingInfos] = useState({});
+  const [settingKeys, setSettingKeys] = useState([]);
+  const [checkChange, setCheckChange] = useState({});
+
+  const [symbolOption, setSymbolOption] = useState([]);
+  const [settingSymbol, setSettingSymbol] = useState('Default');
+
+  useEffect(() => {
+    (async function () {
+      const loadedData = await get_default_settings();
+
+      if (loadedData.message === 'success') {
+        setSettingValues(() => {
+          const newValue = {};
+          Object.keys(loadedData.data.default).forEach(key => {
+            newValue[key] = '';
+          });
+          return newValue;
+        });
+        setSettingInfos(loadedData.data);
+        setSettingKeys(Object.keys(loadedData.data.default));
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const loaded = await getCompanyList();
+      setSymbolOption(
+        loaded.data.map(company => ({
+          label: company[0],
+          value: company[0],
+        })),
+      );
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (settingSymbol !== 'Default') {
+      (async () => {
+        const loadedData = await get_settings(settingSymbol);
+
+        if (loadedData.message === 'success') {
+          setSettingInfos(curr => ({
+            ...curr,
+            default: loadedData.data,
+          }));
+        }
+      })();
+    }
+  }, [settingSymbol]);
+
+  return (
+    <Wrapper>
+      <h2>Settings</h2>
+      <SettingTable>
+        {make_settings_table(
+          settingKeys,
+          settingValues,
+          settingInfos,
+          setSettingValues,
+          checkChange,
+          setCheckChange,
+        )}
+      </SettingTable>
+      <SettingPanel>
+        <p>{settingSymbol}</p>
+        <Select
+          name="symbol"
+          placeHolder="Default"
+          options={symbolOption}
+          onChange={e => {
+            setSettingSymbol(e.value);
+          }}
+        />
+        <button
+          disabled={
+            settingSymbol === 'Default' ||
+            !Object.values(checkChange).includes(true)
+              ? 'disabled'
+              : ''
+          }
+          onClick={() => {
+            apply_new_setting(
+              settingSymbol,
+              settingValues,
+              settingInfos.default,
+              settingInfos.types,
+              setSettingInfos,
+            );
+          }}
+        >
+          Apply new setting
+        </button>
+      </SettingPanel>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: center;
+`;
+
+const SettingTable = styled.div`
+  width: 100%;
+  height: 60vh;
+  padding: 5%;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+
+  border: 1px solid #333;
+  overflow-y: scroll;
+
+  table {
+    width: 100%;
+  }
+
+  table,
+  td {
+    border: 1px solid #333;
+    text-align: center;
+  }
+
+  thead {
+    background-color: #333;
+    color: #fff;
+  }
+`;
+
+const SettingPanel = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+
+  p {
+    font-weight: bold;
+  }
+`;

--- a/services/settingapi.js
+++ b/services/settingapi.js
@@ -1,0 +1,40 @@
+import axios from "axios";
+
+const get_default_settings = async () => {
+  const loaded = await axios({
+    method: 'get',
+    baseURL: process.env.NEXT_PUBLIC_BACKEND_SERVER_URL,
+    url: '/settings',
+  });
+
+  return loaded.data;
+}
+
+const get_settings = async (symbol) => {
+  const loaded = await axios({
+    method: 'get',
+    baseURL: process.env.NEXT_PUBLIC_BACKEND_SERVER_URL,
+    url: `/settings/${symbol}`,
+  });
+
+  return loaded.data;
+}
+
+const set_settings = async (symbol, args) => {
+  const loaded = await axios({
+    method: 'put',
+    baseURL: process.env.NEXT_PUBLIC_BACKEND_SERVER_URL,
+    url: `/settings/${symbol}`,
+    data: {
+      args: args,
+    },
+  });
+
+  return loaded.data;
+}
+
+export {
+  get_default_settings,
+  get_settings,
+  set_settings,
+}

--- a/utils/data_handling.js
+++ b/utils/data_handling.js
@@ -74,17 +74,21 @@ const make_log_table = (logs, sort_function) => {
   });
 
   return (
-    <tbody>
-      <tr>
-        {logKeys.map(key => {
-          if (KEYS_FOR_SORT.includes(key)) {
-            return <th className="keys_for_sort" onClick={() => {sort_function(key)}} key={key}>{key}</th>
-          }
-          return <th key={key}>{key}</th>
-        })}
-      </tr>
-      {contents}
-    </tbody>
+    <table>
+      <thead>
+        <tr>
+          {logKeys.map(key => {
+            if (KEYS_FOR_SORT.includes(key)) {
+              return <th className="keys_for_sort" onClick={() => {sort_function(key)}} key={key}>{key}</th>
+            }
+            return <th key={key}>{key}</th>
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {contents}
+      </tbody>
+    </table>
   );
 }
 

--- a/utils/setting_handling.js
+++ b/utils/setting_handling.js
@@ -1,0 +1,111 @@
+import Select from 'react-select';
+import InputboxMessage from '@/components/micro_components/Inputbox_message';
+
+import { set_settings } from "@/services/settingapi";
+
+const make_settings_table = (settingKeys, settingValues, settingInfos, setSettingValues, checkChange, setCheckChange) => {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Setting items</th>
+          <th>Setting values</th>
+        </tr>
+      </thead>
+      <tbody>
+        {settingKeys.map(key => {
+          if (settingInfos.types[key] === 'select' && settingValues[key] !== '' && checkChange[key] !== (settingValues[key] !== settingInfos.default[key])) {
+            setCheckChange(curr => {
+              const newValue = { ...curr };
+              newValue[key] =
+                settingValues[key] !== settingInfos.default[key];
+              return newValue;
+            });
+          }
+
+          return (
+            <tr key={key}>
+              <td style={{ fontWeight: (checkChange[key] && 'bold') }}>{key}{checkChange[key] && '*'}</td>
+              <td>
+                {settingInfos.default &&
+                  ((settingInfos.types[key] !== 'select' && (
+                    <InputboxMessage
+                      name={key}
+                      defaultValue={settingInfos.default[key]}
+                      type={settingInfos.types[key]}
+                      range={settingInfos.ranges[key]}
+                      value={settingValues[key]}
+                      setSettingValues={setSettingValues}
+                      setCheckChange={setCheckChange}
+                    />
+                  )) ||
+                    (settingInfos.types[key] === 'select' && (
+                      <Select
+                        name={key}
+                        placeholder={settingInfos.default[key]}
+                        options={settingInfos.ranges[key].map(v => {
+                          return {
+                            label: v,
+                            value: v,
+                          };
+                        })}
+                        onChange={e => {
+                          setSettingValues(curr => {
+                            const newValue = { ...curr };
+                            newValue[key] = e.value;
+                            return newValue;
+                          });
+                          setCheckChange(curr => {
+                            const newValue = { ...curr };
+                            newValue[key] =
+                              e.value !== settingInfos.default[key];
+                            return newValue;
+                          });
+                        }}
+                      />
+                    )))}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+const apply_new_setting = async (
+  symbol,
+  settingValues,
+  defaultValues,
+  defaultTypes,
+  setSettingInfos,
+) => {
+  const args = {};
+  Object.keys(settingValues).forEach(key => {
+    if (
+      settingValues[key] !== '' &&
+      settingValues[key] !== defaultValues[key]
+    ) {
+      args[key] = ['int', 'float'].includes(defaultTypes[key])
+        ? Number(settingValues[key])
+        : settingValues[key];
+    }
+  });
+
+  const loadedData = await set_settings(symbol, args);
+
+  if (loadedData.message === 'success') {
+    console.log(`New Setting for ${symbol} is below:`);
+    console.log(loadedData.data);
+
+    setSettingInfos(curr => ({
+      ...curr,
+      default: loadedData.data,
+    }));
+  }
+};
+
+export {
+  make_settings_table,
+  apply_new_setting,
+}


### PR DESCRIPTION
## [#5] FEAT : 종목 거래를 위한 세팅값 조회 및 세팅을 위한 화면과 기능 구성

## 세부 내용

- 초기 화면에 세팅 화면 추가 구성
- default 세팅값 및 세팅 관련 정보 요청하여 사용
- 특정 종목을 선택하면 해당 종목의 세팅값을 확인 가능
- 새로운 값을 입력했을 때 유효성을 검사하고, 유효한 변경인 경우 적용 버튼 활성화
- 적용 버튼 클릭 시 새로운 세팅값 서버에 저장

## 이슈 번호
- Resolved: #5 
